### PR TITLE
drivers/tty/serial: Serial driver prototype.

### DIFF
--- a/kernel/arch/x86/build/Makefile
+++ b/kernel/arch/x86/build/Makefile
@@ -21,7 +21,7 @@ MAKEGEN  := $(CWD)/MakefileX86.gen
 ##
 # Specific CFLAGS for each target described in .mk files
 #
-obj-y-CFLAGS      := $(CFLAGS)
+obj-y-CFLAGS      := -DTKGDB $(CFLAGS)
 obj-x86asm-CFLAGS := -DASM $(CFLAGS)
 
 export obj-y-CFLAGS obj-x86asm-CFLAGS
@@ -53,6 +53,7 @@ $(MAKEGEN): \
 		lib/Build.mk				\
 		drivers/char/Build.mk		\
 		drivers/block/Build.mk		\
+		drivers/tty/serial/Build.mk	\
 		fs/Build.mk					\
 		fs/ext2/Build.mk			\
 		kernel/Build.mk				\

--- a/kernel/drivers/tty/serial/Build.mk
+++ b/kernel/drivers/tty/serial/Build.mk
@@ -1,0 +1,9 @@
+##
+# Copyright (C) 2009 Renê de Souza Pinto
+# TempOS - Tempos is an Educational and multi purpose Operating System
+#
+# TBS - Build configuration file
+#
+
+obj-y += serial.o 
+

--- a/kernel/drivers/tty/serial/serial.c
+++ b/kernel/drivers/tty/serial/serial.c
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2009 Renê de Souza Pinto
+ * Tempos - Tempos is an Educational and multi purpose Operating System
+ *
+ * File: serial.c
+ * Written by: Julio Faracco
+ * Desc: Generic driver for Serial communication
+ *
+ * This file is part of TempOS.
+ *
+ * TempOS is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * TempOS is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <tempos/kernel.h>
+#include <tempos/timer.h>
+#include <tempos/jiffies.h>
+#include <tempos/delay.h>
+#include <tempos/wait.h>
+#include <fs/device.h>
+#include <fs/dev_numbers.h>
+#include <fs/partition.h>
+#include <drv/serial.h>
+#include <arch/irq.h>
+#include <arch/io.h>
+#include <linkedl.h>
+
+static inline void
+serial_out(struct serial_interface *interface, uint16_t addr, uchar8_t val)
+{
+	outb(val, interface->serial_port + addr);
+}
+
+static inline uchar8_t
+serial_in(struct serial_interface *interface, uint16_t addr)
+{
+	return inb(interface->serial_port + addr);
+}
+
+uchar8_t serial_read(struct serial_interface *interface)
+{
+	uchar8_t c;
+
+	serial_init(interface, 115200);
+
+	do {
+		c = serial_in(interface,SERIAL_LSR);
+	} while ((c & 0x1e) || ((c & 1) == 0));
+
+	return serial_in(interface, SERIAL_DLL);
+}
+
+void serial_write(struct serial_interface *interface, char c)
+{
+	serial_init(interface, 115200);
+
+	while ((serial_in(interface,SERIAL_LSR) & 0x20) == 0);
+
+	serial_out(interface,SERIAL_DLL, c);
+}
+
+void serial_flush(void)
+{
+	__asm__ __volatile__ ("jmp 1f\n1:");
+}
+
+int serial_init(struct serial_interface *interface, int baud)
+{
+	interface->serial_port = SERIAL_PORT_COM1;
+
+	serial_out(interface, SERIAL_MCR, SERIAL_LCR_STATE);
+	serial_out(interface, SERIAL_IER, SERIAL_DIS);
+
+	interface->baud = 115200 / baud;
+	serial_out(interface, SERIAL_LCR, 0x83);
+	serial_out(interface, SERIAL_DLL, interface->baud & 0xff);
+	serial_out(interface, SERIAL_DLM, SERIAL_DIS);
+	serial_out(interface, SERIAL_LCR,
+		SERIAL_LCR_8BIT | SERIAL_LCR_1STOP | SERIAL_LCR_NO_PARITY);
+
+	return 1;
+}

--- a/kernel/include/drv/serial.h
+++ b/kernel/include/drv/serial.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2009 Renê de Souza Pinto
+ * Tempos - Tempos is an Educational and multi purpose Operating System
+ *
+ * File: serial.h
+ * Written by: Julio Faracco
+ *
+ * This file is part of TempOS.
+ *
+ * TempOS is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * TempOS is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef _SERIAL_H
+	#define _SERIAL_H
+
+	#define SERIAL_PORT_COM1 0x3f8
+	#define SERIAL_PORT_COM2 0x2f8
+	#define SERIAL_PORT_COM3 0x3e8
+	#define SERIAL_PORT_COM4 0x2e8
+
+	#define	SERIAL_TXR 0
+	#define SERIAL_IER 1
+
+	#define	SERIAL_DLL 0
+	#define SERIAL_DLM 1
+	#define SERIAL_IIF 2
+	#define SERIAL_LCR 3
+	#define SERIAL_MCR 4
+	#define SERIAL_LSR 5
+	#define SERIAL_MSR 6
+	#define SERIAL_SR 7
+
+	#define SERIAL_DIS 0x00
+	#define SERIAL_LCR_STATE 0x0f
+	#define SERIAL_LCR_8BIT	0x03
+	#define SERIAL_LCR_1STOP 0x00
+	#define SERIAL_LCR_NO_PARITY 0x00
+	#define SERIAL_LCR_BREAK 0x40
+	#define SERIAL_LCR_DLAB	0x80
+
+	#define SERIAL_LSR_THR_EMPTY 0x10
+
+	struct serial_interface {
+		unsigned int irq;
+	        uint16_t serial_port;
+	        uint16_t io_size;
+		unsigned int baud;
+		unsigned int stop;
+		unsigned int bits;
+		int parity;
+	};
+
+	struct serial_driver {
+	/* Needs improvement. */
+	/*	void* mem_base; */
+	/*	size_t mem_size; */
+	/*	struct list_element node; */
+	/*	struct device_char char_dev; */
+
+	        int (*init)(struct serial_interface *, int);
+		void (*write)(const struct serial_interface *, char);
+		uchar8_t (*read)(const struct serial_interface*);
+		int (*flush)(const struct serial_interface*);
+	};
+
+	uchar8_t serial_read(struct serial_interface *interface);
+
+	void serial_write(struct serial_interface *interface, char c);
+
+	void serial_flush(void);
+
+	int serial_init(struct serial_interface *interface, int baud);
+
+#endif

--- a/kernel/kernel/kernel.c
+++ b/kernel/kernel/kernel.c
@@ -37,6 +37,9 @@
 #include <stdlib.h>
 #include <linkedl.h>
 #include <semaphore.h>
+#ifdef TKGDB
+#include <drv/serial.h>
+#endif
 
 
 /** information passed from first stage */
@@ -96,6 +99,9 @@ void thread1(void *arg)
 void kernel_main_thread(void *arg)
 {
 	char rdev_str[10], *rstr, *init;
+#ifdef TKGDB
+	char *tkgdb_str;
+#endif
 	dev_t rootdev;
 	size_t i, rdev_len;
 	//task_t *idle_th;
@@ -118,6 +124,19 @@ void kernel_main_thread(void *arg)
 	/* Show and parse command line */
 	kprintf(KERN_INFO "Kernel command line: %s\n", kinfo.cmdline);
 	parse_cmdline((char*)kinfo.cmdline);
+
+#ifdef TKGDB
+	struct serial_interface serial;
+
+	kprintf(KERN_INFO "Using serial.\n");
+	tkgdb_str = cmdline_get_value("kgdbwait");
+	if (tkgdb_str != NULL) {
+		serial_init(&serial, 115200);
+		/* Initialize debugger. */
+	}
+
+        while(1);
+#endif
 
 	/* Mount root file system */
 	rstr = cmdline_get_value("root");

--- a/kernel/scripts/mkdisk_img.sh
+++ b/kernel/scripts/mkdisk_img.sh
@@ -64,7 +64,7 @@ use_grub1() {
 color white/blue light-green/black
 
 title   TempOS
-kernel  /boot/tempos.elf root=3:1 init=/sbin/init
+kernel  /boot/tempos.elf root=3:1 init=/sbin/init kgdbwait=1
 EOF
 	check_result
 
@@ -109,7 +109,7 @@ set menu_color_highlight="light-green/black"
 # TempOS
 #
 menuentry "TempOS" {
-	multiboot /boot/$(basename $TEMPOSFILE) root=3:1 init=/sbin/init
+	multiboot /boot/$(basename $TEMPOSFILE) root=3:1 init=/sbin/init kgdbwait=1
 }
 EOF
 	check_result


### PR DESCRIPTION
Creating a simple prototype for a serial driver. The includes can be found
into includes/drv/serial.h and the main code can be found in a specific
directory for the driver: drivers/tty/serial/serial.c. The commit includes
changes into Makefile and arch/x86/build/Makefile to compile the new driver.
This commit changes the boot command line inside the script mkdisk_img.sh
to enable serial communication passing the parameter 'kgdbwait=1'.

Signed-off-by: Julio C. Faracco jcfaracco@gmail.com
