### PR TITLE
Fixing bugs with VFS and ATA driver.

### DIFF
--- a/kernel/arch/x86/build/Makefile
+++ b/kernel/arch/x86/build/Makefile
@@ -80,7 +80,7 @@ install:
 # test
 #
 test:
-	@[ -f hdisk.img.gz ] || @qemu-system-i386 -M pc -cdrom $(bimage) -boot d &&  ( TEMPOSHD=`mktemp`; gunzip hdisk.img.gz -c > $$TEMPOSHD; qemu-system-i386 -M pc -cdrom $(bimage) -hda $$TEMPOSHD -boot d; rm $$TEMPOSHD )
+	@[ -f hdisk.img.gz ] || @qemu-system-i386 -M pc -cdrom $(bimage) -boot d &&  ( TEMPOSHD=`mktemp`; gunzip hdisk.img.gz -c > $$TEMPOSHD; qemu-system-i386 -M pc -cdrom $(bimage) -hda $$TEMPOSHD -boot d --no-reboot; rm $$TEMPOSHD )
 
 
 ##

--- a/kernel/drivers/block/ata_generic.c
+++ b/kernel/drivers/block/ata_generic.c
@@ -164,7 +164,7 @@ void init_ata_generic(void)
 	char drvl = 'a';
 	uint64_t size;
 	uchar8_t dev, bus;
-	uchar8_t sc, saddr1, saddr2, saddr3;
+	uchar8_t sc, saddr1, saddr2, saddr3, status;
 	
 	kprintf(KERN_INFO "Initializing generic ATA controller...\n");
 
@@ -202,8 +202,10 @@ void init_ata_generic(void)
 		saddr1 = inb(pio_ports[bus][REG_SADDR1]);
 		saddr2 = inb(pio_ports[bus][REG_SADDR2]);
 		saddr3 = inb(pio_ports[bus][REG_SADDR3]);
+		status = inb(pio_ports[bus][REG_ASTATUS]);
 
-		if(sc != 0x01 && saddr1 != 0x01) {
+                /* TODO: Maybe we need to support other kind of ATAs. */
+		if(sc != 0x01 && saddr1 != 0x01 && status == 0) {
 			kprintf(" hd%c: Device not found.\n", drvl);
 			continue;
 		}

--- a/kernel/fs/bhash.c
+++ b/kernel/fs/bhash.c
@@ -298,6 +298,10 @@ static buff_header_t *getblk(int major, int device, uint64_t blocknum)
 
 	driver = block_dev_drivers[major]; 
 
+        if (driver == NULL) {
+                return NULL;
+        }
+
 	while(1) {
 	
 		if ( (buff = search_blk(driver->buffer_queue, device, blocknum)) != NULL ) {
@@ -353,11 +357,16 @@ void brelse(int major, int device, buff_header_t *buff)
 	dev_blk_driver_t *driver;
 	buff_header_t *head, *tmp;
 
-	driver = block_dev_drivers[major]; 
+	driver = block_dev_drivers[major];
 
 	wakeup(WAIT_BLOCK_BUFFER_GET_FREE);
 	wakeup(WAIT_THIS_BLOCK_BUFFER_GET_FREE);
-	
+
+        /* Checking driver pointer after wakeup function. */
+	if (driver == NULL) {
+                return;
+        }
+
 	cli();
 
 	head = driver->buffer_queue->freelist_head;
@@ -397,7 +406,11 @@ buff_header_t *bread(int major, int device, uint64_t blocknum)
 	buff_header_t *buff;
 	dev_blk_driver_t *driver;
 
-	driver = block_dev_drivers[major]; 
+	driver = block_dev_drivers[major];
+
+        if (driver == NULL) {
+                return NULL;
+        }
 
 	if ((buff = getblk(major, device, blocknum)) == NULL) {
 		kprintf(KERN_ERROR "bread(): Error on get cached block.\n");

--- a/kernel/kernel/kernel.c
+++ b/kernel/kernel/kernel.c
@@ -134,7 +134,6 @@ void kernel_main_thread(void *arg)
 		panic("Kernel command line root argument bad formated.");
 	}
 
-	for(;;);
 	if ( !vfs_mount_root(rootdev) ) {
 		panic("VFS ERROR: Could not mount root file system.");
 	}
@@ -144,7 +143,7 @@ void kernel_main_thread(void *arg)
 	if (init == NULL) {
 		init = DEFAULT_INIT_PROCCESS;
 	}
-	kprintf("Loading %s...\n", init); for(;;);
+	kprintf("Loading %s...\n", init);
 
 
 	/* TEST: Read root directory */


### PR DESCRIPTION
The commits fix basically two problems:

1. Null pointer exceptions when a disk is not recognized.
So, a VFS cannot be created and QEMU reboots.

2. ATA disks are not being found. Using another variable to 
check the status of each disk solves the problem with the 
address.