### PR TITLE
drivers/tty/serial: Serial driver prototype [v2].

### DIFF
--- a/kernel/arch/x86/build/Makefile
+++ b/kernel/arch/x86/build/Makefile
@@ -28,6 +28,8 @@ export obj-y-CFLAGS obj-x86asm-CFLAGS
 
 .PHONY: kernel install test clean
 
+QEMU=qemu-system-i386
+
 ##
 # Architecture specific
 #
@@ -53,6 +55,7 @@ $(MAKEGEN): \
 		lib/Build.mk				\
 		drivers/char/Build.mk		\
 		drivers/block/Build.mk		\
+		drivers/tty/serial/Build.mk	\
 		fs/Build.mk					\
 		fs/ext2/Build.mk			\
 		kernel/Build.mk				\
@@ -80,7 +83,7 @@ install:
 # test
 #
 test:
-	@[ -f hdisk.img.gz ] || @qemu-system-i386 -M pc -cdrom $(bimage) -boot d &&  ( TEMPOSHD=`mktemp`; gunzip hdisk.img.gz -c > $$TEMPOSHD; qemu-system-i386 -M pc -cdrom $(bimage) -hda $$TEMPOSHD -boot d --no-reboot; rm $$TEMPOSHD )
+	@[ -f hdisk.img.gz ] || @$(QEMU) -M pc -cdrom $(bimage) -boot d &&  ( TEMPOSHD=`mktemp`; gunzip hdisk.img.gz -c > $$TEMPOSHD; $(QEMU) -M pc -cdrom $(bimage) -hda $$TEMPOSHD -boot d --no-reboot; rm $$TEMPOSHD )
 
 
 ##

--- a/kernel/drivers/tty/serial/Build.mk
+++ b/kernel/drivers/tty/serial/Build.mk
@@ -1,0 +1,8 @@
+##
+# Copyright (C) 2009 Renê de Souza Pinto
+# TempOS - Tempos is an Educational and multi purpose Operating System
+#
+# TBS - Build configuration file
+#
+
+obj-y += serial.o 

--- a/kernel/drivers/tty/serial/serial.c
+++ b/kernel/drivers/tty/serial/serial.c
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2009 Renê de Souza Pinto
+ * Tempos - Tempos is an Educational and multi purpose Operating System
+ *
+ * File: serial.c
+ * Written by: Julio Faracco
+ * Desc: Generic driver for Serial communication
+ *
+ * This file is part of TempOS.
+ *
+ * TempOS is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * TempOS is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <tempos/kernel.h>
+#include <tempos/timer.h>
+#include <tempos/jiffies.h>
+#include <tempos/delay.h>
+#include <tempos/wait.h>
+#include <fs/device.h>
+#include <fs/dev_numbers.h>
+#include <fs/partition.h>
+#include <drv/serial.h>
+#include <arch/irq.h>
+#include <arch/io.h>
+#include <linkedl.h>
+
+static inline void
+serial_out(struct serial_interface *interface, uint16_t addr, uchar8_t val)
+{
+	outb(val, interface->serial_port + addr);
+}
+
+static inline uchar8_t
+serial_in(struct serial_interface *interface, uint16_t addr)
+{
+	return inb(interface->serial_port + addr);
+}
+
+uchar8_t serial_read(struct serial_interface *interface)
+{
+	uchar8_t c;
+
+	do {
+		c = serial_in(interface, SERIAL_LSR);
+	} while ((c & 0x1e) || ((c & 1) == 0));
+
+	return serial_in(interface, SERIAL_DLL);
+}
+
+void serial_write(struct serial_interface *interface, char c)
+{
+	while ((serial_in(interface, SERIAL_LSR) & 0x20) == 0);
+
+	serial_out(interface, SERIAL_DLL, c);
+}
+
+int serial_init(struct serial_interface *interface, int baud)
+{
+	interface->serial_port = SERIAL_PORT_COM1;
+
+	serial_out(interface, SERIAL_MCR, SERIAL_LCR_STATE);
+	serial_out(interface, SERIAL_IER, SERIAL_DIS);
+
+	interface->baud = SERIAL_BAUD_DEFAULT / baud;
+	serial_out(interface, SERIAL_LCR, 0x83);
+	serial_out(interface, SERIAL_DLL, interface->baud & 0xff);
+	serial_out(interface, SERIAL_DLM, SERIAL_DIS);
+	serial_out(interface, SERIAL_LCR,
+		SERIAL_LCR_8BIT | SERIAL_LCR_1STOP | SERIAL_LCR_NO_PARITY);
+
+	return 1;
+}

--- a/kernel/include/drv/serial.h
+++ b/kernel/include/drv/serial.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2009 Renê de Souza Pinto
+ * Tempos - Tempos is an Educational and multi purpose Operating System
+ *
+ * File: serial.h
+ * Written by: Julio Faracco
+ *
+ * This file is part of TempOS.
+ *
+ * TempOS is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * TempOS is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef _SERIAL_H
+	#define _SERIAL_H
+
+	#define SERIAL_PORT_COM1 0x3f8
+	#define SERIAL_PORT_COM2 0x2f8
+	#define SERIAL_PORT_COM3 0x3e8
+	#define SERIAL_PORT_COM4 0x2e8
+
+	#define	SERIAL_TXR 0
+	#define SERIAL_IER 1
+
+	#define	SERIAL_DLL 0
+	#define SERIAL_DLM 1
+	#define SERIAL_IIF 2
+	#define SERIAL_LCR 3
+	#define SERIAL_MCR 4
+	#define SERIAL_LSR 5
+	#define SERIAL_MSR 6
+	#define SERIAL_SR 7
+
+	#define SERIAL_DIS 0x00
+	#define SERIAL_LCR_STATE 0x0f
+	#define SERIAL_LCR_8BIT	0x03
+	#define SERIAL_LCR_1STOP 0x00
+	#define SERIAL_LCR_NO_PARITY 0x00
+	#define SERIAL_LCR_BREAK 0x40
+	#define SERIAL_LCR_DLAB	0x80
+
+	#define SERIAL_LSR_THR_EMPTY 0x10
+
+	#define SERIAL_BAUD_DEFAULT 115200
+
+	struct serial_interface {
+		unsigned int irq;
+	        uint16_t serial_port;
+	        uint16_t io_size;
+		unsigned int baud;
+		unsigned int stop;
+		unsigned int bits;
+		int parity;
+	};
+
+	struct serial_driver {
+	/* Needs improvement. */
+	/* 	void* mem_base; */
+	/* 	size_t mem_size; */
+	/* 	struct list_element node; */
+	/* 	struct device_char char_dev; */
+
+	        int (*init)(struct serial_interface *, int);
+		void (*write)(const struct serial_interface *, char);
+		uchar8_t (*read)(const struct serial_interface*);
+	};
+
+	uchar8_t serial_read(struct serial_interface *interface);
+
+	void serial_write(struct serial_interface *interface, char c);
+
+	int serial_init(struct serial_interface *interface, int baud);
+
+#endif

--- a/kernel/scripts/mkdisk_img.sh
+++ b/kernel/scripts/mkdisk_img.sh
@@ -65,6 +65,9 @@ color white/blue light-green/black
 
 title   TempOS
 kernel  /boot/tempos.elf root=3:1 init=/sbin/init
+
+title	TemOS over serial
+kernel  /boot/tempos.elf root=3:1 init=/sbin/init kgdbwait=1
 EOF
 	check_result
 
@@ -110,6 +113,9 @@ set menu_color_highlight="light-green/black"
 #
 menuentry "TempOS" {
 	multiboot /boot/$(basename $TEMPOSFILE) root=3:1 init=/sbin/init
+}
+menuentry "TempOS over serial" {
+        multiboot /boot/$(basename $TEMPOSFILE) root=3:1 init=/sbin/init kgdbwait=1
 }
 EOF
 	check_result


### PR DESCRIPTION
Creating a simple prototype for a serial driver. The includes can be found
into includes/drv/serial.h and the main code can be found in a specific
directory for the driver: drivers/tty/serial/serial.c. The commit includes
changes into Makefile and arch/x86/build/Makefile to compile the new driver.
This commit changes the boot command line inside the script mkdisk_img.sh
to enable serial communication passing the parameter 'kgdbwait=1'.

Signed-off-by: Julio Faracco <jcfaracco@gmail.com>