### PR TITLE
Allow linker to resolve all tentative definitions of 'IDTR' and 'GDTR'

### DIFF
--- a/kernel/arch/x86/build/Makefile
+++ b/kernel/arch/x86/build/Makefile
@@ -14,7 +14,7 @@ CWD := arch/x86/build
 ARCH_CF  := -m32 -march=i486
 ARCH_LF  := -melf_i386
 INCDIRS  := -I$(PWD)/include -I$(PWD)/arch/include
-CFLAGS   := $(INCDIRS) -fno-builtin -Wall -nostdlib -nodefaultlibs $(ARCH_CF)
+CFLAGS   := $(INCDIRS) -fno-builtin -Wall -nostdlib -nodefaultlibs -fcommon $(ARCH_CF)
 
 MAKEGEN  := $(CWD)/MakefileX86.gen
 


### PR DESCRIPTION
Fix issue #7
Allow linker to resolve all tentative definitions of 'IDTR' and 'GDTR'.

``ld: arch/x86/idt.o: (.bss+0x0): multiple definition of 'IDTR'; arch/x86/boot/karch.o: (.bss+0x0): first defined here
ld: arch/x86/mm/mm.o: (.bss+0x0): multiple definition of 'GDTR'; arch/x86/gdt.o: (.bss+0x0): first defined here``

